### PR TITLE
chore: rename repository references

### DIFF
--- a/packages/osv-offline-updater/src/client/github.ts
+++ b/packages/osv-offline-updater/src/client/github.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 export class GitHub {
   private readonly octokit: Octokit;
   private readonly baseParameters: { owner: string; repo: string } = {
-    owner: 'JamieMagee',
+    owner: 'renovatebot',
     repo: 'osv-offline',
   };
 

--- a/packages/osv-offline/src/lib/download.ts
+++ b/packages/osv-offline/src/lib/download.ts
@@ -11,7 +11,7 @@ import AdmZip from 'adm-zip';
 const pipeline = promisify(Stream.pipeline);
 
 const baseParameters: { owner: string; repo: string } = {
-  owner: 'JamieMagee',
+  owner: 'renovatebot',
   repo: 'osv-offline',
 };
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>JamieMagee/.github"]
+  "extends": ["github>renovatebot/.github"]
 }


### PR DESCRIPTION
This PR changes any references to the old repository, `JamieMagee/osv-offline`, to the new repository, `renovatebot/osv-offline`.