### PR TITLE
chore: rename packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A collection of packages for using [Open Source Vulnerabilities](https://osv.dev
 
 | Name                                                                | Version                                                                                                                                              |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@jamiemagee/osv-offline`](./packages/osv-offline)                 | [![](https://img.shields.io/npm/v/@jamiemagee/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@jamiemagee/osv-offline)               |
-| [`@jamiemagee/osv-offline-db`](./packages/osv-offline-db)           | [![](https://img.shields.io/npm/v/@jamiemagee/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@jamiemagee/osv-offline-db)         |
-| [`@jamiemagee/osv-offline-updater`](./packages/osv-offline-updater) | [![](https://img.shields.io/github/v/release/jamiemagee/osv-offline?style=for-the-badge)](https://github.com/jamiemagee/osv-offline/releases/latest) |
+| [`@renovatebot/osv-offline`](./packages/osv-offline)                 | [![](https://img.shields.io/npm/v/@renovatebot/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline)               |
+| [`@renovatebot/osv-offline-db`](./packages/osv-offline-db)           | [![](https://img.shields.io/npm/v/@renovatebot/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline-db)         |
+| [`@renovatebot/osv-offline-updater`](./packages/osv-offline-updater) | [![](https://img.shields.io/github/v/release/jamiemagee/osv-offline?style=for-the-badge)](https://github.com/jamiemagee/osv-offline/releases/latest) |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@jamiemagee/osv-offline-monorepo",
+  "name": "@renovatebot/osv-offline-monorepo",
   "version": "0.0.0-semantic-release",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@jamiemagee/osv-offline-monorepo",
+      "name": "@renovatebot/osv-offline-monorepo",
       "version": "0.0.0-semantic-release",
       "workspaces": [
         "./packages/*"
@@ -749,18 +749,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jamiemagee/osv-offline": {
-      "resolved": "packages/osv-offline",
-      "link": true
-    },
-    "node_modules/@jamiemagee/osv-offline-db": {
-      "resolved": "packages/osv-offline-db",
-      "link": true
-    },
-    "node_modules/@jamiemagee/osv-offline-updater": {
-      "resolved": "packages/osv-offline-updater",
-      "link": true
-    },
     "node_modules/@jest/console": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
@@ -1421,6 +1409,18 @@
         "node": ">=12.20",
         "yarn": ">=1.0.0"
       }
+    },
+    "node_modules/@renovatebot/osv-offline": {
+      "resolved": "packages/osv-offline",
+      "link": true
+    },
+    "node_modules/@renovatebot/osv-offline-db": {
+      "resolved": "packages/osv-offline-db",
+      "link": true
+    },
+    "node_modules/@renovatebot/osv-offline-updater": {
+      "resolved": "packages/osv-offline-updater",
+      "link": true
     },
     "node_modules/@seald-io/binary-search-tree": {
       "version": "1.0.2",
@@ -12590,12 +12590,12 @@
       }
     },
     "packages/osv-offline": {
-      "name": "@jamiemagee/osv-offline",
+      "name": "@renovatebot/osv-offline",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
         "@octokit/rest": "19.0.4",
+        "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
         "adm-zip": "^0.5.9",
         "fs-extra": "10.0.0",
         "got": "11.8.5",
@@ -12612,7 +12612,7 @@
       }
     },
     "packages/osv-offline-db": {
-      "name": "@jamiemagee/osv-offline-db",
+      "name": "@renovatebot/osv-offline-db",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
@@ -12633,12 +12633,12 @@
       "dev": true
     },
     "packages/osv-offline-updater": {
-      "name": "@jamiemagee/osv-offline-updater",
+      "name": "@renovatebot/osv-offline-updater",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
         "@octokit/rest": "19.0.4",
+        "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
         "@seald-io/nedb": "3.0.0",
         "adm-zip": "0.5.9",
         "fs-extra": "10.0.1",
@@ -13298,129 +13298,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@jamiemagee/osv-offline": {
-      "version": "file:packages/osv-offline",
-      "requires": {
-        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
-        "@octokit/rest": "19.0.4",
-        "@types/adm-zip": "0.5.0",
-        "@types/fs-extra": "9.0.13",
-        "@types/luxon": "3.0.0",
-        "@types/node": "16.11.52",
-        "adm-zip": "^0.5.9",
-        "fs-extra": "10.0.0",
-        "got": "11.8.5",
-        "luxon": "3.0.1",
-        "prettier": "2.7.1",
-        "ts-node": "10.9.1",
-        "typescript": "4.7.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.11.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.52.tgz",
-          "integrity": "sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        }
-      }
-    },
-    "@jamiemagee/osv-offline-db": {
-      "version": "file:packages/osv-offline-db",
-      "requires": {
-        "@seald-io/nedb": "3.0.0",
-        "@tsconfig/node14": "1.0.3",
-        "@types/node": "16.11.52",
-        "prettier": "2.7.1",
-        "ts-node": "10.9.1",
-        "typescript": "4.7.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.11.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.52.tgz",
-          "integrity": "sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==",
-          "dev": true
-        }
-      }
-    },
-    "@jamiemagee/osv-offline-updater": {
-      "version": "file:packages/osv-offline-updater",
-      "requires": {
-        "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
-        "@octokit/rest": "19.0.4",
-        "@seald-io/nedb": "3.0.0",
-        "@tsconfig/node14": "1.0.3",
-        "@types/adm-zip": "0.5.0",
-        "@types/fs-extra": "9.0.13",
-        "@types/luxon": "3.0.0",
-        "@types/node": "16.11.52",
-        "@types/signale": "1.4.4",
-        "adm-zip": "0.5.9",
-        "fs-extra": "10.0.1",
-        "got": "11.8.5",
-        "luxon": "3.0.1",
-        "prettier": "2.7.1",
-        "signale": "1.4.0",
-        "ts-node": "10.9.1",
-        "typescript": "4.7.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.11.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.52.tgz",
-          "integrity": "sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        }
-      }
-    },
     "@jest/console": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
@@ -13954,6 +13831,129 @@
         "semver": "^7.3.7",
         "signale": "^1.4.0",
         "stream-buffers": "^3.0.2"
+      }
+    },
+    "@renovatebot/osv-offline": {
+      "version": "file:packages/osv-offline",
+      "requires": {
+        "@octokit/rest": "19.0.4",
+        "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
+        "@types/adm-zip": "0.5.0",
+        "@types/fs-extra": "9.0.13",
+        "@types/luxon": "3.0.0",
+        "@types/node": "16.11.52",
+        "adm-zip": "^0.5.9",
+        "fs-extra": "10.0.0",
+        "got": "11.8.5",
+        "luxon": "3.0.1",
+        "prettier": "2.7.1",
+        "ts-node": "10.9.1",
+        "typescript": "4.7.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.11.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.52.tgz",
+          "integrity": "sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
+    "@renovatebot/osv-offline-db": {
+      "version": "file:packages/osv-offline-db",
+      "requires": {
+        "@seald-io/nedb": "3.0.0",
+        "@tsconfig/node14": "1.0.3",
+        "@types/node": "16.11.52",
+        "prettier": "2.7.1",
+        "ts-node": "10.9.1",
+        "typescript": "4.7.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.11.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.52.tgz",
+          "integrity": "sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==",
+          "dev": true
+        }
+      }
+    },
+    "@renovatebot/osv-offline-updater": {
+      "version": "file:packages/osv-offline-updater",
+      "requires": {
+        "@octokit/rest": "19.0.4",
+        "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
+        "@seald-io/nedb": "3.0.0",
+        "@tsconfig/node14": "1.0.3",
+        "@types/adm-zip": "0.5.0",
+        "@types/fs-extra": "9.0.13",
+        "@types/luxon": "3.0.0",
+        "@types/node": "16.11.52",
+        "@types/signale": "1.4.4",
+        "adm-zip": "0.5.9",
+        "fs-extra": "10.0.1",
+        "got": "11.8.5",
+        "luxon": "3.0.1",
+        "prettier": "2.7.1",
+        "signale": "1.4.0",
+        "ts-node": "10.9.1",
+        "typescript": "4.7.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.11.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.52.tgz",
+          "integrity": "sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
       }
     },
     "@seald-io/binary-search-tree": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jamiemagee/osv-offline-monorepo",
+  "name": "@renovatebot/osv-offline-monorepo",
   "private": true,
   "workspaces": [
     "./packages/*"

--- a/packages/osv-offline-db/README.md
+++ b/packages/osv-offline-db/README.md
@@ -1,6 +1,6 @@
 # osv-offline-db
 
-[![Package version](https://img.shields.io/npm/v/@jamiemagee/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@jamiemagee/osv-offline-db)
+[![Package version](https://img.shields.io/npm/v/@renovatebot/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline-db)
 [![Build status](https://img.shields.io/github/workflow/status/jamiemagee/osv-offline/Build?style=for-the-badge)](https://github.com/jamiemagee/osv-offline/actions/workflows/build.yml)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](./LICENSE)
 ![Stability experimental](https://img.shields.io/badge/stability-experimental-orange.svg?style=for-the-badge)

--- a/packages/osv-offline-db/package.json
+++ b/packages/osv-offline-db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jamiemagee/osv-offline-db",
+  "name": "@renovatebot/osv-offline-db",
   "version": "0.0.0-semantic-release",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/osv-offline-updater/package.json
+++ b/packages/osv-offline-updater/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jamiemagee/osv-offline-updater",
+  "name": "@renovatebot/osv-offline-updater",
   "version": "0.0.0-semantic-release",
   "main": "src/index.ts",
   "license": "MIT",
@@ -8,7 +8,7 @@
     "start": "ts-node ./src/index.ts"
   },
   "dependencies": {
-    "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
+    "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
     "@octokit/rest": "19.0.4",
     "@seald-io/nedb": "3.0.0",
     "adm-zip": "0.5.9",

--- a/packages/osv-offline-updater/src/client/osv.ts
+++ b/packages/osv-offline-updater/src/client/osv.ts
@@ -2,7 +2,7 @@ import { format } from 'util';
 
 import AdmZip from 'adm-zip';
 import got from 'got';
-import type { Ecosystem, Osv } from '@jamiemagee/osv-offline-db';
+import type { Ecosystem, Osv } from '@renovatebot/osv-offline-db';
 
 export class OsvDownloader {
   private static readonly downloadUrlFormat =

--- a/packages/osv-offline-updater/src/index.ts
+++ b/packages/osv-offline-updater/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import { Osv, OsvOfflineDb, ecosystems } from '@jamiemagee/osv-offline-db';
+import { Osv, OsvOfflineDb, ecosystems } from '@renovatebot/osv-offline-db';
 import { GitHub } from './client/github';
 import signale from 'signale';
 import Datastore from '@seald-io/nedb';

--- a/packages/osv-offline/README.md
+++ b/packages/osv-offline/README.md
@@ -1,6 +1,6 @@
 # osv-offline
 
-[![Package version](https://img.shields.io/npm/v/@jamiemagee/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@jamiemagee/osv-offline)
+[![Package version](https://img.shields.io/npm/v/@renovatebot/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline)
 [![Build status](https://img.shields.io/github/workflow/status/jamiemagee/osv-offline/Build?style=for-the-badge)](https://github.com/jamiemagee/osv-offline/actions/workflows/build.yml)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](./LICENSE)
 ![Stability experimental](https://img.shields.io/badge/stability-experimental-orange.svg?style=for-the-badge)

--- a/packages/osv-offline/package.json
+++ b/packages/osv-offline/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jamiemagee/osv-offline",
+  "name": "@renovatebot/osv-offline",
   "version": "0.0.0-semantic-release",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@jamiemagee/osv-offline-db": "0.0.0-semantic-release",
+    "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
     "@octokit/rest": "19.0.4",
     "adm-zip": "^0.5.9",
     "fs-extra": "10.0.0",

--- a/packages/osv-offline/src/index.ts
+++ b/packages/osv-offline/src/index.ts
@@ -1,2 +1,2 @@
-export { Osv, Ecosystem } from '@jamiemagee/osv-offline-db';
+export { Osv, Ecosystem } from '@renovatebot/osv-offline-db';
 export { OsvOffline } from './lib/osv-offline';

--- a/packages/osv-offline/src/lib/download.int.spec.ts
+++ b/packages/osv-offline/src/lib/download.int.spec.ts
@@ -1,4 +1,4 @@
-import { OsvOfflineDb } from '@jamiemagee/osv-offline-db';
+import { OsvOfflineDb } from '@renovatebot/osv-offline-db';
 import fs from 'fs-extra';
 import path from 'path';
 import { tryDownloadDb } from './download';

--- a/packages/osv-offline/src/lib/download.ts
+++ b/packages/osv-offline/src/lib/download.ts
@@ -3,7 +3,7 @@ import { Octokit } from '@octokit/rest';
 import got from 'got';
 import { Stream } from 'stream';
 import { promisify } from 'util';
-import { OsvOfflineDb } from '@jamiemagee/osv-offline-db';
+import { OsvOfflineDb } from '@renovatebot/osv-offline-db';
 import path from 'path';
 import { DateTime } from 'luxon';
 import AdmZip from 'adm-zip';

--- a/packages/osv-offline/src/lib/osv-offline.int.spec.ts
+++ b/packages/osv-offline/src/lib/osv-offline.int.spec.ts
@@ -1,4 +1,4 @@
-import { OsvOfflineDb } from '@jamiemagee/osv-offline-db';
+import { OsvOfflineDb } from '@renovatebot/osv-offline-db';
 import fs from 'fs-extra';
 import { OsvOffline } from './osv-offline';
 

--- a/packages/osv-offline/src/lib/osv-offline.ts
+++ b/packages/osv-offline/src/lib/osv-offline.ts
@@ -1,4 +1,4 @@
-import { Ecosystem, Osv, OsvOfflineDb } from '@jamiemagee/osv-offline-db';
+import { Ecosystem, Osv, OsvOfflineDb } from '@renovatebot/osv-offline-db';
 import { tryDownloadDb } from './download';
 
 export class OsvOffline {

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -4,7 +4,7 @@
     // ts-jest doesn't understand project references, so tell it how to find our packages
     // (see https://github.com/kulshekhar/ts-jest/issues/1648)
     "paths": {
-      "@jamiemagee/*": ["./packages/*"]
+      "@renovatebot/*": ["./packages/*"]
     }
   }
 }


### PR DESCRIPTION
This renames the packages from the `@jamiemagee` to the `@renovatebot` scope. However #53 is required to be completed to publish the packages.