### PR TITLE
chore: make latestRelease optional

### DIFF
--- a/packages/osv-offline/src/lib/download.ts
+++ b/packages/osv-offline/src/lib/download.ts
@@ -40,7 +40,7 @@ export async function tryDownloadDb(): Promise<boolean> {
     })
   ).data[0];
 
-  const asset = latestRelease.assets.find(
+  const asset = latestRelease?.assets.find(
     (asset) => asset.name === 'osv-offline.zip'
   );
 


### PR DESCRIPTION
When building this project with `strictMode` enabled, it fails with error:
```
packages/osv-offline/src/lib/download.ts:43:17 - error TS18048: 'latestRelease' is possibly 'undefined'.

43   const asset = latestRelease.assets.find(
                   ~~~~~~~~~~~~~
```