### PR TITLE
feat: add support for fetching releases using GitHub token

### DIFF
--- a/packages/osv-offline/src/lib/download.int.spec.ts
+++ b/packages/osv-offline/src/lib/download.int.spec.ts
@@ -28,5 +28,11 @@ describe('lib/download', () => {
       const stat = await fs.stat(zipFilePath);
       expect(stat.size).toBe(0);
     });
+
+    it('skips download in case of invalid GitHub token', async () => {
+      process.env.GITHUB_COM_TOKEN = 'some-token';
+
+      await expect(tryDownloadDb()).resolves.toBeFalse();
+    });
   });
 });

--- a/packages/osv-offline/src/lib/download.ts
+++ b/packages/osv-offline/src/lib/download.ts
@@ -34,11 +34,20 @@ export async function tryDownloadDb(): Promise<boolean> {
     return true;
   }
 
-  const latestRelease = (
-    await new Octokit().repos.listReleases({
-      ...baseParameters,
-    })
-  ).data[0];
+  const octokitOptions = process.env.GITHUB_COM_TOKEN
+    ? { auth: process.env.GITHUB_COM_TOKEN }
+    : undefined;
+
+  let latestRelease = null;
+  try {
+    latestRelease = (
+      await new Octokit(octokitOptions).repos.listReleases({
+        ...baseParameters,
+      })
+    ).data[0];
+  } catch (err) {
+    return false;
+  }
 
   const asset = latestRelease?.assets.find(
     (asset) => asset.name === 'osv-offline.zip'


### PR DESCRIPTION
**Problem**

GitHub imposes a limit of 60 unauthenticated API req / h when listing releases via REST. Fetching available `osv-offline.zip` releases may fail and lead to an exception in renovate.

<details><summary>Renovate logs</summary>

```
WARN: Unable to read vulnerability information (repository=some/demo)
  "err": {
    "name": "HttpError",
    "status": 403,
    "response": {
      "url": "https://api.github.com/repos/renovatebot/osv-offline/releases",
      "status": 403,
      "headers": {
        "access-control-allow-origin": "*",
        "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-RateLimit-Used, X-RateLimit-Resource, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
        "connection": "close",
        "content-length": "280",
        "content-security-policy": "default-src 'none'; style-src 'unsafe-inline'",
        "content-type": "application/json; charset=utf-8",
        "date": "Mon, 13 Feb 2023 15:18:28 GMT",
        "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
        "server": "Varnish",
        "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
        "x-content-type-options": "nosniff",
        "x-frame-options": "deny",
        "x-github-media-type": "github.v3; format=json",
        "x-github-request-id": "42FE:CF4C:B98C343:BCEC281:64FA54C4",
        "x-ratelimit-limit": "60",
        "x-ratelimit-remaining": "0",
        "x-ratelimit-reset": "1676303034",
        "x-ratelimit-resource": "core",
        "x-ratelimit-used": "60",
        "x-xss-protection": "1; mode=block"
      },
      "data": {
        "message": "API rate limit exceeded for 12.34.56.78. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
        "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"
      }
    },
    "request": {
      "method": "GET",
      "url": "https://api.github.com/repos/renovatebot/osv-offline/releases",
      "headers": {
        "accept": "application/vnd.github.v3+json",
        "user-agent": "octokit-rest.js/19.0.7 octokit-core.js/4.2.0 Node.js/16.19.0 (linux; x64)"
      },
      "request": {"hook": "[function]"}
    },
    "message": "API rate limit exceeded for 12.34.56.78. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
    "stack": "HttpError: API rate limit exceeded for 12.34.56.78. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)\n    at 
	/opt/buildpack/tools/renovate/34.133.0/node_modules/@octokit/request/dist-src/fetch-wrapper.js:70:27\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at tryDownloadDb 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/@renovatebot/osv-offline/dist/lib/download.js:35:28)\n    at OsvOffline.initialize 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/@renovatebot/osv-offline/dist/lib/osv-offline.js:13:25)\n    at Function.create 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/@renovatebot/osv-offline/dist/lib/osv-offline.js:25:9)\n    at Vulnerabilities.initialize 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/repository/process/vulnerabilities.ts:44:23)\n    at Function.create 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/repository/process/vulnerabilities.ts:49:5)\n    at fetchVulnerabilities 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/repository/process/extract-update.ts:176:31)\n    at lookup 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/repository/process/extract-update.ts:188:3)\n    at extractDependencies 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/repository/process/index.ts:127:11)\n    at Object.renovateRepository 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/repository/index.ts:56:9)\n    at attributes.repository 
	(/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/global/index.ts:181:11)\n    at start (/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/workers/global/index.ts:166:7)\n    at 
	/opt/buildpack/tools/renovate/34.133.0/node_modules/renovate/lib/renovate.ts:18:22"
  }
```
</details>

**Solution**

If provided, reuse the GitHub token provided to renovate via the `GITHUB_COM_TOKEN` environment variable. The interface is kept consistent with the second `catch` with the idea in mind that in case of invalid token or other errors, a fallback to a bundled offline DB (see https://github.com/renovatebot/osv-offline/pull/88) may happen.

Side note: Wrapping the list releases call using try/catch also addresses the concerns I raised in https://github.com/renovatebot/osv-offline/pull/88#issuecomment-1404098721

The database download URL itself is not rate-limited:
* It sends no rate limit header and req / res header look no different regardless if I send a token or not
* I repeatedly downloaded the ZIP file unauthenticated ~ 1.5k times. Presumably, the rate limit per IP address would kick in after 5,000 requests - not verified though.