### PR TITLE
fix: use `node-fetch` as Octokit's fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,6 +2246,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -2802,6 +2812,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -3284,6 +3300,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -4101,6 +4129,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/deprecation": {
@@ -5107,6 +5144,20 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/from2": {
@@ -7477,6 +7528,27 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -12982,13 +13054,15 @@
         "adm-zip": "~0.5.10",
         "fs-extra": "^11.1.1",
         "got": "^11.8.6",
-        "luxon": "^3.3.0"
+        "luxon": "^3.3.0",
+        "node-fetch": "^2.6.9"
       },
       "devDependencies": {
         "@types/adm-zip": "0.5.0",
         "@types/fs-extra": "11.0.1",
         "@types/luxon": "3.2.0",
         "@types/node": "18.15.7",
+        "@types/node-fetch": "2.6.3",
         "prettier": "2.8.7",
         "ts-node": "10.9.1",
         "typescript": "5.0.2"

--- a/packages/osv-offline/package.json
+++ b/packages/osv-offline/package.json
@@ -13,13 +13,15 @@
     "adm-zip": "~0.5.10",
     "fs-extra": "^11.1.1",
     "got": "^11.8.6",
-    "luxon": "^3.3.0"
+    "luxon": "^3.3.0",
+    "node-fetch": "^2.6.9"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.0",
     "@types/fs-extra": "11.0.1",
     "@types/luxon": "3.2.0",
     "@types/node": "18.15.7",
+    "@types/node-fetch": "2.6.3",
     "prettier": "2.8.7",
     "ts-node": "10.9.1",
     "typescript": "5.0.2"

--- a/packages/osv-offline/src/lib/download.ts
+++ b/packages/osv-offline/src/lib/download.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import fetch from 'node-fetch';
 import { Octokit } from '@octokit/rest';
 import got from 'got';
 import { Stream } from 'stream';
@@ -34,9 +35,7 @@ export async function tryDownloadDb(): Promise<boolean> {
     return true;
   }
 
-  const octokitOptions = process.env.GITHUB_COM_TOKEN
-    ? { auth: process.env.GITHUB_COM_TOKEN }
-    : undefined;
+  const octokitOptions = { auth: process.env.GITHUB_COM_TOKEN, request: { fetch } };
 
   let latestRelease = null;
   try {


### PR DESCRIPTION
In v6.1.0 Octokit started using Node.js's built-in `fetch`[^1] provided by [undici][1]. Unfortunately, it is not 100% compatible with `node-fetch`, and notably it doesn't support `HTTP_PROXY` environment variables[^2].

This change switches `osv-offline` to explicitly use `node-fetch`.

Closes #252

[1]: https://github.com/nodejs/undici

[^1]: https://github.com/octokit/request.js/commit/d000a0ab58b6b60872190d26e4952d3e0a863499
[^2]: https://github.com/nodejs/undici/issues/1650