### PR TITLE
docs: remove experimental stability badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A collection of packages for using [Open Source Vulnerabilities](https://osv.dev/) in Node.js.
 
-![stability-experimental](https://img.shields.io/badge/stability-experimental-orange.svg?style=for-the-badge)
-
 ## Packages
 
 | Name                                                                | Version                                                                                                                                               |


### PR DESCRIPTION
It's been used in Renovate for months now. It should be considered stable.