### PR TITLE
feat: provide better information from `throw`s

### DIFF
--- a/packages/osv-offline/src/lib/download.int.spec.ts
+++ b/packages/osv-offline/src/lib/download.int.spec.ts
@@ -10,7 +10,9 @@ describe('lib/download', () => {
     });
 
     it('works', async () => {
-      await expect(tryDownloadDb()).resolves.not.toThrow();
+      const result = await tryDownloadDb();
+
+      expect(result.success).toBeTrue();
       expect(fs.stat(OsvOfflineDb.rootDirectory)).toBeDefined();
       expect(fs.readdir(OsvOfflineDb.rootDirectory)).not.toBeEmptyArray();
     });
@@ -23,8 +25,9 @@ describe('lib/download', () => {
       );
       await fs.ensureFile(zipFilePath);
 
-      await tryDownloadDb();
+      const result = await tryDownloadDb();
 
+      expect(result.success).toBeTrue();
       const stat = await fs.stat(zipFilePath);
       expect(stat.size).toBe(0);
     });
@@ -32,7 +35,9 @@ describe('lib/download', () => {
     it('skips download in case of invalid GitHub token', async () => {
       process.env['GITHUB_COM_TOKEN'] = 'some-token';
 
-      await expect(tryDownloadDb()).resolves.toBeFalse();
+      const result = await tryDownloadDb();
+
+      expect(result.success).toBeFalse();
     });
   });
 });

--- a/packages/osv-offline/src/lib/download.unit.spec.ts
+++ b/packages/osv-offline/src/lib/download.unit.spec.ts
@@ -1,5 +1,0 @@
-describe('lib/download', () => {
-  it('works', () => {
-    expect(true).toBeTrue();
-  });
-});

--- a/packages/osv-offline/src/lib/osv-offline.ts
+++ b/packages/osv-offline/src/lib/osv-offline.ts
@@ -11,9 +11,9 @@ export class OsvOffline {
    * Asynchronous code required as part of class instantiation
    */
   private async initialize(): Promise<void> {
-    const success = await tryDownloadDb();
-    if (!success) {
-      throw new Error();
+    const result = await tryDownloadDb();
+    if (!result.success) {
+      throw result.error;
     }
     this.osvOfflineDb = await OsvOfflineDb.create();
   }

--- a/packages/osv-offline/src/lib/types.ts
+++ b/packages/osv-offline/src/lib/types.ts
@@ -1,0 +1,11 @@
+type Success = { success: true };
+type Failure = { success: false; error: Error };
+export type Result = Success | Failure;
+
+export function success(): Success {
+  return { success: true };
+}
+
+export function failure(error: Error): Failure {
+  return { success: false, error };
+}


### PR DESCRIPTION
Use the result pattern to return errors from `tryDownloadDb()`

Closes #364