### PR TITLE
feat: add support for CVSS v4.0

### DIFF
--- a/packages/osv-offline-db/src/lib/osv.ts
+++ b/packages/osv-offline-db/src/lib/osv.ts
@@ -34,7 +34,7 @@ export interface Severity {
   score: string;
 }
 
-export type SeverityType = 'CVSS_V3' | 'CVSS_V2';
+export type SeverityType = 'CVSS_V4' | 'CVSS_V3' | 'CVSS_V2';
 
 export interface Package {
   ecosystem: string;


### PR DESCRIPTION
OSV schema 1.6.2 ([ref](https://github.com/ossf/osv-schema/releases/tag/v1.6.2)) added support for [CVSS v4](https://ossf.github.io/osv-schema/#severitytype-field) and this PR also adds it to the `osv-offline` library.

Since it is only an extension of the type, I have omitted adding a separate test for it.