### PR TITLE
build: add engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "5.7.3"
   },
   "engines": {
-    "node": ">=18.12.0",
+    "node": ">=22.12.0",
     "pnpm": "^10.0.0"
   },
   "packageManager": "pnpm@10.3.0"

--- a/packages/osv-offline-db/package.json
+++ b/packages/osv-offline-db/package.json
@@ -19,5 +19,8 @@
     "@tsconfig/strictest": "1.0.2",
     "@types/fs-extra": "11.0.4",
     "fs-extra": "11.3.0"
+  },
+  "engines": {
+    "node": ">=18.12.0"
   }
 }

--- a/packages/osv-offline/package.json
+++ b/packages/osv-offline/package.json
@@ -22,5 +22,8 @@
     "@types/adm-zip": "0.5.7",
     "@types/fs-extra": "11.0.4",
     "@types/luxon": "3.4.2"
+  },
+  "engines": {
+    "node": ">=18.12.0"
   }
 }


### PR DESCRIPTION
We already only support node v18+, so the published packages express the intend now with engines.
Dev requirement is now node v22.12 to allow using esm from cjs